### PR TITLE
Add Image.build and fix a couple of bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your application's `shard.yml`:
 dependencies:
   crymagick:
     github: imdrasil/crymagick
-    version: 0.2.2
+    version: 0.2.3
 ```
 
 ## Requirements

--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,10 @@
 name: crymagick
-version: 0.2.2
+version: 0.2.3
 
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: 1.0.0
+crystal: ">= 0.35.0"
 
 license: MIT
 development_dependencies:

--- a/spec/support/helper.cr
+++ b/spec/support/helper.cr
@@ -33,7 +33,7 @@ module Helper
       File.join("spec", "fixtures", name)
     else
       path = random_path
-      FileUtils.cp image_path, path
+      FileUtils.cp(image_path, path)
       path
     end
   end
@@ -52,5 +52,11 @@ module Helper
     io = IO::Memory.new
     array.each { |e| io.write_bytes(e) }
     io.to_s
+  end
+
+  def clone_image(path)
+    new_path = random_path
+    FileUtils.cp(path, new_path)
+    new_path
   end
 end

--- a/src/crymagick.cr
+++ b/src/crymagick.cr
@@ -3,5 +3,5 @@ require "./crymagick/errors"
 require "./crymagick/*"
 
 module CryMagick
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/src/crymagick/image/info.cr
+++ b/src/crymagick/image/info.cr
@@ -38,6 +38,7 @@ module CryMagick
       def clear
         @info.clear
         @resolution.clear
+        @data = nil
         {% for attr in ALL_ATTRS %}
           {% if attr != "resolution" %}
             @{{attr.id}} = nil

--- a/src/crymagick/tool.cr
+++ b/src/crymagick/tool.cr
@@ -2,12 +2,6 @@ module CryMagick
   class Tool
     CREATION_OPERATORS = %w(xc canvas logo rose gradient radial-gradient plasma pattern label caption text pango)
 
-    def self.build(name : String) : String
-      instance = new(name)
-      yield instance
-      instance.call
-    end
-
     getter name : String, args
     @whiny : Bool
 
@@ -19,6 +13,12 @@ module CryMagick
     def initialize(@name, options : Hash(Symbol, Bool) = {} of Symbol => Bool)
       @args = [] of String
       @whiny = options.has_key?(:whiny) ? options[:whiny] : Configuration.whiny
+    end
+
+    def self.build(name : String) : String
+      instance = new(name)
+      yield instance
+      instance.call
     end
 
     def call : String
@@ -101,9 +101,7 @@ module CryMagick
     # Currently notification about dynamically generated methods will be printed out
     # to stdout during compilation
     macro method_missing(call)
-      {% if flag?(:crymagick_debug) %}
-        {% p "#{@type}##{call.id} is generated".id %}
-      {% end %}
+      {% flag?(:crymagick_debug) && p("#{@type}##{call.id} is generated".id) %}
       def {{call.name.id}}(*args)
         send({{call.name.tr("_", "-").id.stringify}}, *args)
       end

--- a/src/crymagick/tool/mogrify_restricted.cr
+++ b/src/crymagick/tool/mogrify_restricted.cr
@@ -1,0 +1,9 @@
+require "./mogrify"
+
+class CryMagick::Tool
+  class MogrifyRestricted < Mogrify
+    def format(*args)
+      raise ArgumentError.new("you must call #format on a CryMagick::Image directly")
+    end
+  end
+end


### PR DESCRIPTION
Fix #8 

#### Changes

* add missing `CryMagick::Image.build` method
* disallow to call `#format` inside of `CryMagick::Image#combine_options`
* relax language version restriction
* fix `CryMagcik::Image::Info#clear` not clearing out `data`